### PR TITLE
develop MergeListTag filter

### DIFF
--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/cleaning/Pipeline.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/cleaning/Pipeline.scala
@@ -32,6 +32,8 @@ case class Paragraph(
     nearFreq: Int = 1,
     remove: AnyRef = null
 ) {
+  final val cssSelectorSeparator = ">"
+
   def renderInto[T <: Appendable](bldr: T): T = {
     if (path != null && path.nonEmpty) {
       bldr.append(path)
@@ -40,6 +42,8 @@ case class Paragraph(
     bldr.append(text)
     bldr
   }
+
+  def cssSelectors: Seq[String] = this.path.split(cssSelectorSeparator)
 
   def isAlive: Boolean = remove == null
   def isDeleted: Boolean = !isAlive

--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/MergeListTag.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/MergeListTag.scala
@@ -1,0 +1,89 @@
+package com.worksap.nlp.uzushio.lib.filters
+
+import com.worksap.nlp.uzushio.lib.filters.base.DocFilter
+import com.worksap.nlp.uzushio.lib.cleaning.{Document, Paragraph}
+import scala.collection.mutable.{ArrayBuffer, Queue}
+
+class MergeListTag extends DocFilter {
+  final val listTagString = "li"
+  final val mdListSymbol = "- "
+
+  def containsListTag(cssSelectorStrs: Seq[String]): Boolean = {
+    extractDescendantTag(cssSelectorStrs, listTagString) match {
+      case Some(_) => true
+      case None => false
+    }
+  }
+
+  def extractDescendantTag(cssSelectorStrs: Seq[String], tagName: String): Option[String] = {
+    val iter = cssSelectorStrs.reverse.iterator
+
+    while (iter.hasNext) {
+      val tagWithCSS = iter.next()
+      val tagWithAttrs = tagWithCSS.split("[#\\.]")
+      if (tagWithAttrs.head == tagName) {
+        return Option(tagWithCSS)
+      }
+    }
+    return None
+  }
+
+  def mergeListParagraphs(listTagParagraphs: Seq[Paragraph]): Seq[Paragraph] = {
+    val listParsGroup = listTagParagraphs
+      .groupBy(par => extractDescendantTag(par.cssSelectors, listTagString).get)
+
+    listParsGroup.map {
+      case (tagName, groupedPars) => {
+        val exactFreqs = groupedPars.map(par => par.exactFreq)
+        val nearFreqs = groupedPars.map(par => par.nearFreq)
+        val listTexts = groupedPars.map(par => mdListSymbol + par.text)
+        val text = listTexts.mkString("\n")
+        val mergedListParagraph = groupedPars.head
+          .copy(text = text, exactFreq = exactFreqs.min, nearFreq = nearFreqs.min)
+
+        // for consistency of paragraph index
+        val tail = groupedPars.tail.map(par => par.copy(remove = par))
+        mergedListParagraph +: tail
+      }
+    }.flatten.to[Seq]
+  }
+
+  def findConsecutiveListTag(paragraphs: Seq[Paragraph]): Seq[Paragraph] = {
+    var isListBlock = true
+    val listTagParagraphs = ArrayBuffer.empty[Paragraph]
+    val iter = paragraphs.iterator
+    while (isListBlock && iter.hasNext) {
+      val paragraph = iter.next
+      isListBlock = containsListTag(paragraph.cssSelectors)
+      if (isListBlock) {
+        listTagParagraphs.append(paragraph)
+      }
+    }
+    listTagParagraphs
+  }
+
+  override def checkDocument(doc: Document): Document = {
+    val paragraphs = doc.aliveParagraphs.to[Seq]
+    val iter = paragraphs.iterator.zipWithIndex
+    val newParagraphs = ArrayBuffer.empty[Paragraph]
+    val listTagParagraphQueue = Queue[Paragraph]()
+
+    while (iter.hasNext) {
+      val (paragraph, i) = iter.next
+      val cssSelectorStrs = paragraph.cssSelectors
+
+      if (listTagParagraphQueue.isEmpty && containsListTag(cssSelectorStrs)) {
+        val listTagParagraphs = findConsecutiveListTag(paragraphs.drop(i))
+        listTagParagraphQueue ++= mergeListParagraphs(listTagParagraphs)
+        newParagraphs += listTagParagraphQueue.dequeue
+      } else if (!listTagParagraphQueue.isEmpty) {
+        // if queue is not empty, add merged paragraph or remove-signed one
+        newParagraphs += listTagParagraphQueue.dequeue
+      } else {
+        newParagraphs += paragraph.copy()
+      }
+    }
+
+    doc.copy(paragraphs = newParagraphs)
+  }
+}

--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/MergeListTag.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/MergeListTag.scala
@@ -15,7 +15,10 @@ class MergeListTag extends DocFilter {
     }
   }
 
-  def extractDescendantTagWithParentSelectors(cssSelectorStrs: Seq[String], tagNames: Seq[String]): Option[Tuple2[String, Seq[String]]] = {
+  def extractDescendantTagWithParentSelectors(
+      cssSelectorStrs: Seq[String],
+      tagNames: Seq[String]
+  ): Option[Tuple2[String, Seq[String]]] = {
     val iter = cssSelectorStrs.reverse.iterator
     var i = 0
 
@@ -48,11 +51,14 @@ class MergeListTag extends DocFilter {
     (0 until paragraphs.length - 1).foreach { i =>
       val paragraph = paragraphs(i)
       val nextParagraph = paragraphs(i + 1)
-      val isAccteptedTags = containsAcceptedTag(paragraph.cssSelectors) && containsAcceptedTag(nextParagraph.cssSelectors)
+      val isAccteptedTags = containsAcceptedTag(paragraph.cssSelectors) && containsAcceptedTag(
+        nextParagraph.cssSelectors
+      )
 
       if (isAccteptedTags && matchesTagAndParentPath(paragraph, nextParagraph)) {
         val mergedParagraph = nextParagraph.copy(
-          text = List(paragraph.text, nextParagraph.text).map(s => if (s.startsWith(mdListSymbol)) s else mdListSymbol + s).mkString("\n"),
+          text = List(paragraph.text, nextParagraph.text)
+            .map(s => if (s.startsWith(mdListSymbol)) s else mdListSymbol + s).mkString("\n"),
           exactFreq = math.min(paragraph.exactFreq, nextParagraph.exactFreq),
           nearFreq = math.min(paragraph.nearFreq, nextParagraph.nearFreq)
         )

--- a/lib/src/test/scala/com/worksap/nlp/uzushio/lib/cleaning/ParagraphSpec.scala
+++ b/lib/src/test/scala/com/worksap/nlp/uzushio/lib/cleaning/ParagraphSpec.scala
@@ -1,0 +1,12 @@
+package com.worksap.nlp.uzushio.lib.cleaning
+
+import org.scalatest.freespec.AnyFreeSpec
+
+class ParagraphSpec extends AnyFreeSpec {
+  "Paragraph" - {
+    "return css selector strings" in {
+      val par = Paragraph("body>p.text", "hello")
+      assert(par.cssSelectors == Seq("body", "p.text"))
+    }
+  }
+}

--- a/lib/src/test/scala/com/worksap/nlp/uzushio/lib/filters/MergeListTagSpec.scala
+++ b/lib/src/test/scala/com/worksap/nlp/uzushio/lib/filters/MergeListTagSpec.scala
@@ -1,7 +1,6 @@
 package com.worksap.nlp.uzushio.lib.filters
 
 import com.worksap.nlp.uzushio.lib.cleaning.Document
-import com.worksap.nlp.uzushio.lib.utils.Paragraphs
 import org.scalatest.freespec.AnyFreeSpec
 
 class MergeListTagSpec extends AnyFreeSpec {
@@ -19,18 +18,18 @@ class MergeListTagSpec extends AnyFreeSpec {
     }
 
     "merge list tag texts and put 'remove' sign on rests for document including list tags" in {
-      val texts = Seq("test 1", "li test 1", "li test 2", "li test 3", "li test 4", "li test 5", "test 2")
-      val nearFreqs = Seq(1, 2, 3, 5, 4, 1, 1)
-      val exactFreqs = Seq(1, 2, 3, 5, 4, 1, 1)
-      val paths = Seq("body>p.text", "body>ul>li.text", "body>ul>li.text", "body>ul>li.text2", "body>ul>li.text2", "body>ul>li.text3", "body>p.text")
+      val texts = Seq("test 1", "li test 1", "li test 2", "li test 3", "li test 4", "li test 5", "li test 6", "option test 1", "option test 2", "test 2")
+      val nearFreqs = Seq(1, 2, 3, 5, 4, 1, 1, 1, 2, 1)
+      val exactFreqs = Seq(1, 2, 3, 5, 4, 1, 1, 1, 2, 1)
+      val paths = Seq("body>p.text", "body>ul>li.text", "body>ul>li.text", "body>ul>li.text2", "body>ul>li.text2", "body>ul>li.text2", "body>ul>li.text3", "body>datalist>option.text", "body>datalist>option.text", "body>p.text")
       val paragraphs = testParagraphs(texts, nearFreqs, exactFreqs, paths)
       val doc = Document(paragraphs)
 
-      assert(Seq("test 1", "- li test 1\n- li test 2", "- li test 3\n- li test 4", "- li test 5", "test 2") == filter.checkDocument(doc).aliveParagraphs.map(_.text).toSeq)
+      assert(Seq("test 1", "- li test 1\n- li test 2", "- li test 3\n- li test 4\n- li test 5", "li test 6", "- option test 1\n- option test 2", "test 2") == filter.checkDocument(doc).aliveParagraphs.map(_.text).toSeq)
       assert(2 == filter.checkDocument(doc).aliveParagraphs.map(_.nearFreq).drop(1).toList.head)
       assert(2 == filter.checkDocument(doc).aliveParagraphs.map(_.exactFreq).drop(1).toList.head)
-      assert(Seq(false, false, true, false, true, false, false) == filter.checkDocument(doc).paragraphs.map(_.remove != null))
-      assert(Seq("body>p.text", "body>ul>li.text", "body>ul>li.text2", "body>ul>li.text3", "body>p.text") == filter.checkDocument(doc).aliveParagraphs.map(_.path).toSeq)
+      assert(Seq(false, true, false, true, true, false, false, true, false, false) == filter.checkDocument(doc).paragraphs.map(_.remove != null))
+      assert(Seq("body>p.text", "body>ul>li.text", "body>ul>li.text2", "body>ul>li.text3", "body>datalist>option.text", "body>p.text") == filter.checkDocument(doc).aliveParagraphs.map(_.path).toSeq)
     }
   }
 }

--- a/lib/src/test/scala/com/worksap/nlp/uzushio/lib/filters/MergeListTagSpec.scala
+++ b/lib/src/test/scala/com/worksap/nlp/uzushio/lib/filters/MergeListTagSpec.scala
@@ -1,0 +1,36 @@
+package com.worksap.nlp.uzushio.lib.filters
+
+import com.worksap.nlp.uzushio.lib.cleaning.Document
+import com.worksap.nlp.uzushio.lib.utils.Paragraphs
+import org.scalatest.freespec.AnyFreeSpec
+
+class MergeListTagSpec extends AnyFreeSpec {
+  "MergeListTag" - {
+    val filter = new MergeListTag()
+    "do no operation for empty document" in {
+      val doc = testDoc("")
+      assert("" == filter.checkDocument(doc).aliveParagraphs.map(_.text).mkString(""))
+    }
+
+    "do no operation for no list document" in {
+      val texts = Seq("test 1", "test 2", "test 3")
+      val doc = Document(testParagraphs(texts))
+      assert(texts.mkString("") == filter.checkDocument(doc).aliveParagraphs.map(_.text).mkString(""))
+    }
+
+    "merge list tag texts and put 'remove' sign on rests for document including list tags" in {
+      val texts = Seq("test 1", "li test 1", "li test 2", "li test 3", "test 2")
+      val nearFreqs = Seq(1, 2, 3, 4, 1)
+      val exactFreqs = Seq(1, 2, 3, 4, 1)
+      val paths = Seq("body>p.text", "body>li.text", "body>li.text", "body>li.text", "body>p.text")
+      val paragraphs = testParagraphs(texts, nearFreqs, exactFreqs, paths)
+      val doc = Document(paragraphs)
+
+      assert(Seq("test 1", "- li test 1\n- li test 2\n- li test 3", "test 2") == filter.checkDocument(doc).aliveParagraphs.map(_.text).toSeq)
+      assert(2 == filter.checkDocument(doc).aliveParagraphs.map(_.nearFreq).drop(1).toList.head)
+      assert(2 == filter.checkDocument(doc).aliveParagraphs.map(_.exactFreq).drop(1).toList.head)
+      assert(Seq(false, false, true, true, false) == filter.checkDocument(doc).paragraphs.map(_.remove != null))
+      assert(Seq("body>p.text", "body>li.text", "body>p.text") == filter.checkDocument(doc).aliveParagraphs.map(_.path).toSeq)
+    }
+  }
+}

--- a/lib/src/test/scala/com/worksap/nlp/uzushio/lib/filters/MergeListTagSpec.scala
+++ b/lib/src/test/scala/com/worksap/nlp/uzushio/lib/filters/MergeListTagSpec.scala
@@ -19,18 +19,18 @@ class MergeListTagSpec extends AnyFreeSpec {
     }
 
     "merge list tag texts and put 'remove' sign on rests for document including list tags" in {
-      val texts = Seq("test 1", "li test 1", "li test 2", "li test 3", "test 2")
-      val nearFreqs = Seq(1, 2, 3, 4, 1)
-      val exactFreqs = Seq(1, 2, 3, 4, 1)
-      val paths = Seq("body>p.text", "body>li.text", "body>li.text", "body>li.text", "body>p.text")
+      val texts = Seq("test 1", "li test 1", "li test 2", "li test 3", "li test 4", "li test 5", "test 2")
+      val nearFreqs = Seq(1, 2, 3, 5, 4, 1, 1)
+      val exactFreqs = Seq(1, 2, 3, 5, 4, 1, 1)
+      val paths = Seq("body>p.text", "body>ul>li.text", "body>ul>li.text", "body>ul>li.text2", "body>ul>li.text2", "body>ul>li.text3", "body>p.text")
       val paragraphs = testParagraphs(texts, nearFreqs, exactFreqs, paths)
       val doc = Document(paragraphs)
 
-      assert(Seq("test 1", "- li test 1\n- li test 2\n- li test 3", "test 2") == filter.checkDocument(doc).aliveParagraphs.map(_.text).toSeq)
+      assert(Seq("test 1", "- li test 1\n- li test 2", "- li test 3\n- li test 4", "- li test 5", "test 2") == filter.checkDocument(doc).aliveParagraphs.map(_.text).toSeq)
       assert(2 == filter.checkDocument(doc).aliveParagraphs.map(_.nearFreq).drop(1).toList.head)
       assert(2 == filter.checkDocument(doc).aliveParagraphs.map(_.exactFreq).drop(1).toList.head)
-      assert(Seq(false, false, true, true, false) == filter.checkDocument(doc).paragraphs.map(_.remove != null))
-      assert(Seq("body>p.text", "body>li.text", "body>p.text") == filter.checkDocument(doc).aliveParagraphs.map(_.path).toSeq)
+      assert(Seq(false, false, true, false, true, false, false) == filter.checkDocument(doc).paragraphs.map(_.remove != null))
+      assert(Seq("body>p.text", "body>ul>li.text", "body>ul>li.text2", "body>ul>li.text3", "body>p.text") == filter.checkDocument(doc).aliveParagraphs.map(_.path).toSeq)
     }
   }
 }

--- a/lib/src/test/scala/com/worksap/nlp/uzushio/lib/filters/package.scala
+++ b/lib/src/test/scala/com/worksap/nlp/uzushio/lib/filters/package.scala
@@ -32,10 +32,20 @@ package object filters {
     )
   }
 
-  def testParagraphs(texts: Seq[String], nearFreqs: Seq[Int]): IndexedSeq[Paragraph] = {
-      (texts, nearFreqs)
-        .zipped
-        .map ((text, freq) => Paragraph("", text, 0, 1, freq))
-        .toIndexedSeq
+  def testParagraphs(texts: Seq[String], nearFreqs: Seq[Int] = Seq(), exactFreqs: Seq[Int] = Seq(), paths: Seq[String] = Seq()): IndexedSeq[Paragraph] = {
+    require(texts.length == nearFreqs.length || nearFreqs.isEmpty)
+    require(texts.length == exactFreqs.length || exactFreqs.isEmpty)
+    require(texts.length == paths.length || paths.isEmpty)
+
+    val nearFreqs_ = if (!nearFreqs.isEmpty) nearFreqs else Seq.fill(texts.length)(1)
+    val exactFreqs_ = if (!exactFreqs.isEmpty) exactFreqs else Seq.fill(texts.length)(1)
+    val paths_ = if (!paths.isEmpty) paths else 0.to(texts.length).map(_ => "body>p.text")
+
+    texts
+      .zip(nearFreqs_)
+      .zip(exactFreqs_)
+      .zip(paths_)
+      .map { case (((text, nearFreq), exactFreq), path) => Paragraph(path, text, 0, exactFreq, nearFreq) }
+      .toIndexedSeq
   }
 }


### PR DESCRIPTION
Add MergeListTag into filters.

This filter merges consecutive paragraphs including the `li` and `option` tag.

When scanning a paragraph list and there are adjacent paragraphs containing li / option tags, merge them into the paragraph on the right and add a remove sign to the paragraph on the left.