### PR TITLE
develop `MarkdownizeHeading` filter

### DIFF
--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/cleaning/Pipeline.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/cleaning/Pipeline.scala
@@ -43,8 +43,29 @@ case class Paragraph(
     bldr
   }
 
-  def cssSelectors: Seq[String] = this.path.split(cssSelectorSeparator)
+  def containsTags(tagNames: Seq[String]): Boolean = {
+    extractDescendantTag(tagNames) match {
+      case Some(_) => true
+      case None => false
+    }
+  }
 
+  def extractDescendantTag(tagNames: Seq[String]): Option[String] = {
+    val iter = cssSelectors.reverse.iterator
+    var i = 0
+
+    while (iter.hasNext) {
+      val tagWithCSS = iter.next()
+      val tagWithAttrs = tagWithCSS.split("[#\\.]")
+      i += 1
+      if (tagNames.contains(tagWithAttrs.head)) {
+        return Option(tagWithAttrs.head)
+      }
+    }
+    return None
+  }
+
+  def cssSelectors: Seq[String] = this.path.split(cssSelectorSeparator)
   def isAlive: Boolean = remove == null
   def isDeleted: Boolean = !isAlive
 }

--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/MarkdownizeHeading.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/MarkdownizeHeading.scala
@@ -1,0 +1,27 @@
+package com.worksap.nlp.uzushio.lib.filters
+
+import com.worksap.nlp.uzushio.lib.cleaning.Paragraph
+import com.worksap.nlp.uzushio.lib.filters.base.ParagraphFilter
+
+class MarkdownizeHeading extends ParagraphFilter {
+  final val acceptedTags = Seq("h1", "h2", "h3", "h4", "h5", "h6")
+  final val mdHeadningSymbol = "#"
+
+  def tagToMarkdownSymbol(tag: String): String = {
+    val numHeading = acceptedTags.indexOf(tag) + 1
+
+    if (numHeading == 0) {
+      throw new IllegalArgumentException(s"tag $tag is not heading")
+    }
+
+    mdHeadningSymbol * numHeading + " "
+  }
+
+  override def checkParagraph(p: Paragraph): Paragraph = {
+    val tagWithCSS = p.extractDescendantTag(acceptedTags)
+    tagWithCSS match {
+      case Some(v) => p.copy(text = tagToMarkdownSymbol(v) + p.text)
+      case None => p
+    }
+  }
+}

--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/MergeListTag.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/MergeListTag.scala
@@ -13,7 +13,8 @@ class MergeListTag extends DocFilter {
     (0 until paragraphs.length - 1).foreach { i =>
       val paragraph = paragraphs(i)
       val nextParagraph = paragraphs(i + 1)
-      val isAccteptedTags = paragraph.containsTags(acceptedTags) && nextParagraph.containsTags(acceptedTags)
+      val isAccteptedTags = paragraph.containsTags(acceptedTags) && nextParagraph
+        .containsTags(acceptedTags)
 
       if (isAccteptedTags && paragraph.path == nextParagraph.path) {
         val mergedParagraph = nextParagraph.copy(

--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/MergeListTag.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/MergeListTag.scala
@@ -7,40 +7,13 @@ class MergeListTag extends DocFilter {
   final val acceptedTags = Seq("li", "option")
   final val mdListSymbol = "- "
 
-  def containsAcceptedTag(cssSelectorStrs: Seq[String]): Boolean = {
-    extractDescendantTag(cssSelectorStrs, acceptedTags) match {
-      case Some(_) => true
-      case None => false
-    }
-  }
-
-  def extractDescendantTag(
-      cssSelectorStrs: Seq[String],
-      tagNames: Seq[String]
-  ): Option[String] = {
-    val iter = cssSelectorStrs.reverse.iterator
-    var i = 0
-
-    while (iter.hasNext) {
-      val tagWithCSS = iter.next()
-      val tagWithAttrs = tagWithCSS.split("[#\\.]")
-      i += 1
-      if (acceptedTags.contains(tagWithAttrs.head)) {
-        return Option(tagWithCSS)
-      }
-    }
-    return None
-  }
-
   override def checkDocument(doc: Document): Document = {
     var paragraphs = doc.aliveParagraphs.to[Seq]
 
     (0 until paragraphs.length - 1).foreach { i =>
       val paragraph = paragraphs(i)
       val nextParagraph = paragraphs(i + 1)
-      val isAccteptedTags = containsAcceptedTag(paragraph.cssSelectors) && containsAcceptedTag(
-        nextParagraph.cssSelectors
-      )
+      val isAccteptedTags = paragraph.containsTags(acceptedTags) && nextParagraph.containsTags(acceptedTags)
 
       if (isAccteptedTags && paragraph.path == nextParagraph.path) {
         val mergedParagraph = nextParagraph.copy(

--- a/lib/src/test/scala/com/worksap/nlp/uzushio/lib/cleaning/ParagraphSpec.scala
+++ b/lib/src/test/scala/com/worksap/nlp/uzushio/lib/cleaning/ParagraphSpec.scala
@@ -4,9 +4,29 @@ import org.scalatest.freespec.AnyFreeSpec
 
 class ParagraphSpec extends AnyFreeSpec {
   "Paragraph" - {
-    "return css selector strings" in {
+    "can return css selector strings" in {
       val par = Paragraph("body>p.text", "hello")
       assert(par.cssSelectors == Seq("body", "p.text"))
+    }
+
+    "can return designated tags in path without css selector" in {
+      val par = Paragraph("body>p.text", "hello")
+      assert(par.extractDescendantTag(Seq("p", "span")) == Some("p"))
+    }
+
+    "do not return designated tags in path" in {
+      val par = Paragraph("body>p.text", "hello")
+      assert(par.extractDescendantTag(Seq("span")) == None)
+    }
+
+    "can return true if the paragraph contains designated tags" in {
+      val par = Paragraph("body>p.text", "hello")
+      assert(par.containsTags(Seq("p", "span")))
+    }
+
+    "do not return true if the paragraph does not contain designated tags" in {
+      val par = Paragraph("body>p.text", "hello")
+      assert(!par.containsTags(Seq("span")))
     }
   }
 }

--- a/lib/src/test/scala/com/worksap/nlp/uzushio/lib/filters/MarkdownizeHeadingSpec.scala
+++ b/lib/src/test/scala/com/worksap/nlp/uzushio/lib/filters/MarkdownizeHeadingSpec.scala
@@ -1,0 +1,50 @@
+package com.worksap.nlp.uzushio.lib.filters
+
+import com.worksap.nlp.uzushio.lib.cleaning.Paragraph
+import org.scalatest.freespec.AnyFreeSpec
+
+class MarkdownizeHeadingSpec extends AnyFreeSpec {
+  "MarkdownizeHeading" - {
+    val filter = new MarkdownizeHeading()
+
+    "do no operation for empty paragraph" in {
+      val p = Paragraph("body>p.text", "")
+      assert("" == filter.checkParagraph(p).text)
+    }
+
+    "do no operation for no heading paragraph" in {
+      val p = Paragraph("body>p.text", "test")
+      assert("test" == filter.checkParagraph(p).text)
+    }
+
+    "add markdown heading symbol for h1 paragraph" in {
+       val p = Paragraph("body>h1.text", "test")
+       assert("# test" == filter.checkParagraph(p).text)
+    }
+
+    "add markdown heading symbol for h2 paragraph" in {
+       val p = Paragraph("body>h2.text", "test")
+       assert("## test" == filter.checkParagraph(p).text)
+    }
+
+    "add markdown heading symbol for h3 paragraph" in {
+       val p = Paragraph("body>h3.text", "test")
+       assert("### test" == filter.checkParagraph(p).text)
+    }
+
+    "add markdown heading symbol for h4 paragraph" in {
+       val p = Paragraph("body>h4.text", "test")
+       assert("#### test" == filter.checkParagraph(p).text)
+    }
+
+    "add markdown heading symbol for h5 paragraph" in {
+       val p = Paragraph("body>h5.text", "test")
+       assert("##### test" == filter.checkParagraph(p).text)
+    }
+
+    "add markdown heading symbol for h6 paragraph" in {
+       val p = Paragraph("body>h6.text", "test")
+       assert("###### test" == filter.checkParagraph(p).text)
+    }
+  }
+}


### PR DESCRIPTION
Add `MarkdownizeHeading` into filters.

This filter convert heading tags to markdown format in  paragraph.

This filter checks if `Paragraph .path` has a heading tag (`h1`, `h2`, `h3`, ...), and adds the heading symbol of Markdown into the head of the text if the heading tag exists.