### PR TITLE
Develop HTML-based No content tags filter

### DIFF
--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/cleaning/Pipeline.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/cleaning/Pipeline.scala
@@ -52,12 +52,10 @@ case class Paragraph(
 
   def extractDescendantTag(tagNames: Seq[String]): Option[String] = {
     val iter = cssSelectors.reverse.iterator
-    var i = 0
 
     while (iter.hasNext) {
       val tagWithCSS = iter.next()
       val tagWithAttrs = tagWithCSS.split("[#\\.]")
-      i += 1
       if (tagNames.contains(tagWithAttrs.head)) {
         return Option(tagWithAttrs.head)
       }

--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOM.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOM.scala
@@ -8,7 +8,11 @@ class NoContentDOM extends ParagraphFilter {
   final val filteringDomNames = Seq("header", "footer", "aside", "nav")
 
   // I checked some of the Common Crawl extracts and noticed that `div#header` and `div.nav` are also often used instead of `<header>` and `<nav>`.
-  def containsTagWithIdAndClasses(p: Paragraph, tagName: String, classOrIdNames: Seq[String]): Boolean = {
+  def containsTagWithIdAndClasses(
+      p: Paragraph,
+      tagName: String,
+      classOrIdNames: Seq[String]
+  ): Boolean = {
     val iter = p.cssSelectors.reverse.iterator
 
     while (iter.hasNext) {
@@ -22,7 +26,9 @@ class NoContentDOM extends ParagraphFilter {
   }
 
   override def checkParagraph(p: Paragraph): Paragraph = {
-    if (p.containsTags(filteringDomNames) || containsTagWithIdAndClasses(p, "div", filteringDomNames)) {
+    if (
+      p.containsTags(filteringDomNames) || containsTagWithIdAndClasses(p, "div", filteringDomNames)
+    ) {
       p.copy(remove = p)
     } else {
       p

--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOM.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOM.scala
@@ -1,0 +1,31 @@
+package com.worksap.nlp.uzushio.lib.filters
+
+import com.worksap.nlp.uzushio.lib.cleaning.Paragraph
+import com.worksap.nlp.uzushio.lib.filters.base.ParagraphFilter
+
+class NoContentDOM extends ParagraphFilter {
+  // This names are tag names, but also class names and id names
+  final val filteringDomNames = Seq("header", "footer", "aside", "nav")
+
+  // I checked some of the Common Crawl extracts and noticed that `div#header` and `div.nav` are also often used instead of `<header>` and `<nav>`.
+  def containsTagWithIdAndClasses(p: Paragraph, tagName: String, classOrIdNames: Seq[String]): Boolean = {
+    val iter = p.cssSelectors.reverse.iterator
+
+    while (iter.hasNext) {
+      val tagWithCSS = iter.next()
+      val tagWithAttrs = tagWithCSS.split("[#\\.]")
+      if (tagWithAttrs.head == tagName && !(tagWithAttrs.tail.toSet & classOrIdNames.toSet).isEmpty) {
+        return true
+      }
+    }
+    return false
+  }
+
+  override def checkParagraph(p: Paragraph): Paragraph = {
+    if (p.containsTags(filteringDomNames) || containsTagWithIdAndClasses(p, "div", filteringDomNames)) {
+      p.copy(remove = p)
+    } else {
+      p
+    }
+  }
+}

--- a/lib/src/test/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOMSpec.scala
+++ b/lib/src/test/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOMSpec.scala
@@ -1,0 +1,45 @@
+package com.worksap.nlp.uzushio.lib.filters
+
+import com.worksap.nlp.uzushio.lib.cleaning.Paragraph
+import org.scalatest.freespec.AnyFreeSpec
+
+class NoContentDOMSpec extends AnyFreeSpec {
+  "NoContentDOM" - {
+    val filter = new NoContentDOM()
+
+    "do no operation for paragraph in tag that be able to have content" in {
+      val p = Paragraph("body>article>p", "text")
+      assert(filter.checkParagraph(p).remove == null)
+    }
+
+    "sign remove for header tag paragraph" in {
+      val p = Paragraph("body>header>p", "test")
+      assert(filter.checkParagraph(p).remove != null)
+    }
+
+    "sign remove for footer tag paragraph" in {
+      val p = Paragraph("body>footer>p", "test")
+      assert(filter.checkParagraph(p).remove != null)
+    }
+
+    "sign remove for aside tag paragraph" in {
+      val p = Paragraph("body>aside>p", "test")
+      assert(filter.checkParagraph(p).remove != null)
+    }
+
+    "sign remove for nav tag paragraph" in {
+      val p = Paragraph("body>nav>p", "test")
+      assert(filter.checkParagraph(p).remove != null)
+    }
+
+    "sign remove for div tag with header class paragraph" in {
+      val p = Paragraph("body>div.header>p", "test")
+      assert(filter.checkParagraph(p).remove != null)
+    }
+
+    "sign remove for div tag with header id paragraph" in {
+      val p = Paragraph("body>div#header>p", "test")
+      assert(filter.checkParagraph(p).remove != null)
+    }
+  }
+}


### PR DESCRIPTION
I developed HTML-based no content tags filter.

For example, This filter removes paragraphs held following paths.

- `body>nav>p`
- `body>header>h2`
- `body>footer>div`
- `body>aside>div#menu`
- `body>div#header`
- `body>div.nav`
- `body>div#footer`
