### PR TITLE
Enriched NoContentFilter

### DIFF
--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/cleaning/PathSegment.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/cleaning/PathSegment.scala
@@ -6,8 +6,8 @@ case class PathSegment(tag: String, id: String, classes: Seq[String]) {
   override def toString: String = classes
     .mkString(tag + (if (classes.isEmpty) "" else "."), ".", if (id == null) "" else s"#$id")
 
-  def splitIdByCase: Seq[String] = id.split("[_-]")
-  def splitClassesByCase: Seq[Array[String]] = classes.map(_.split("[_-]"))
+  lazy val lowerClasses: Set[String] = classes.map(_.toLowerCase).toSet
+  lazy val lowerId: String = if (id == null) null else id.toLowerCase
 }
 
 object PathSegment {

--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/cleaning/PathSegment.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/cleaning/PathSegment.scala
@@ -5,6 +5,9 @@ import scala.collection.mutable.ArrayBuffer
 case class PathSegment(tag: String, id: String, classes: Seq[String]) {
   override def toString: String = classes
     .mkString(tag + (if (classes.isEmpty) "" else "."), ".", if (id == null) "" else s"#$id")
+
+  def splitIdByCase: Seq[String] = id.split("[_-]")
+  def splitClassesByCase: Seq[Array[String]] = classes.map(_.split("[_-]"))
 }
 
 object PathSegment {

--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOM.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOM.scala
@@ -46,7 +46,7 @@ class NoContentDOM extends ParagraphFilter {
       .map(toCamelCase)
 
   def toCamelCase(s: String): String = {
-    val words = s.split("-")
+    val words = s.split("[_-]")
     words.head + words.tail.map(_.capitalize).mkString
   }
 
@@ -80,7 +80,7 @@ class NoContentDOM extends ParagraphFilter {
         return true
       }
 
-      // checking filtering keywords in snake case and camel case, kebab case
+      // check filtering keywords in snake case, camel case and kebab case
       if (
         partialMatchCandidates.exists(name =>
           tagNames.contains(css.tag) && (partialMatchIds(css) || partialMatchClasses(css))

--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOM.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOM.scala
@@ -58,7 +58,7 @@ class NoContentDOM extends ParagraphFilter {
     val id_segments = css.id.split("[_-]")
 
     (id_segments.toSet & filteringPartialMatchClassOrIdNames.toSet).nonEmpty ||
-      filteringPartialMatchClassOrIdNames.exists(name => css.id.capitalize.contains(name.capitalize))
+    filteringPartialMatchClassOrIdNames.exists(name => css.id.capitalize.contains(name.capitalize))
   }
 
   def partialMatchClasses(css: PathSegment): Boolean = {

--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOM.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOM.scala
@@ -50,17 +50,24 @@ class NoContentDOM extends ParagraphFilter {
     words.head + words.tail.map(_.capitalize).mkString
   }
 
-  def partialMatchIds(css: PathSegment): Boolean = filteringPartialMatchClassOrIdNames
-    .exists(name =>
-      css.id != null && (css.id.split("[_-]").contains(name) || css.id.capitalize
-        .contains(name.capitalize))
-    )
+  def partialMatchIds(css: PathSegment): Boolean = {
+    if (css.id == null) {
+      return false
+    }
 
-  def partialMatchClasses(css: PathSegment): Boolean = filteringPartialMatchClassOrIdNames
-    .exists(name =>
-      css.classes.exists(_.split("[_-]").contains(name)) || css.classes
-        .exists(_.capitalize.contains(name.capitalize))
-    )
+    val id_segments = css.id.split("[_-]")
+
+    (id_segments.toSet & filteringPartialMatchClassOrIdNames.toSet).nonEmpty ||
+      filteringPartialMatchClassOrIdNames.exists(name => css.id.capitalize.contains(name.capitalize))
+  }
+
+  def partialMatchClasses(css: PathSegment): Boolean = {
+    val class_segments = css.classes.flatMap(_.split("[_-]"))
+
+    (class_segments.toSet & filteringPartialMatchClassOrIdNames.toSet).nonEmpty ||
+    (class_segments.map(_.capitalize).toSet & filteringPartialMatchClassOrIdNames.map(_.capitalize)
+      .toSet).nonEmpty
+  }
 
   def containsTagWithIdAndClasses(
       p: Paragraph,

--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOM.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOM.scala
@@ -37,7 +37,6 @@ class NoContentDOM extends ParagraphFilter {
     "breadcrumb",
     "breadcrumbs",
     "widget",
-    // "profile",
     "button",
   )
 
@@ -55,18 +54,18 @@ class NoContentDOM extends ParagraphFilter {
       return false
     }
 
-    val id_segments = css.id.split("[_-]")
+    val idSegments = css.splitIdByCase.toSet
 
-    (id_segments.toSet & filteringPartialMatchClassOrIdNames.toSet).nonEmpty ||
-    filteringPartialMatchClassOrIdNames.exists(name => css.id.capitalize.contains(name.capitalize))
+    filteringPartialMatchClassOrIdNames
+      .exists(name => idSegments.contains(name) || css.id.capitalize.contains(name.capitalize))
   }
 
   def partialMatchClasses(css: PathSegment): Boolean = {
-    val class_segments = css.classes.flatMap(_.split("[_-]"))
+    val classSegments = css.splitClassesByCase.flatten.toSet
 
-    (class_segments.toSet & filteringPartialMatchClassOrIdNames.toSet).nonEmpty ||
-    (class_segments.map(_.capitalize).toSet & filteringPartialMatchClassOrIdNames.map(_.capitalize)
-      .toSet).nonEmpty
+    filteringPartialMatchClassOrIdNames.exists(name =>
+      classSegments.contains(name) || css.classes.exists(_.capitalize.contains(name.capitalize))
+    )
   }
 
   def containsTagWithIdAndClasses(

--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOM.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOM.scala
@@ -12,7 +12,6 @@ class NoContentDOM extends ParagraphFilter {
   final private val filteringFullMatchClassOrIdCandidates: Seq[String] = Array(
     "left-box",
     "blog-title-inner",
-    "globalheader",
     "blogtitle",
     "blog-name",
     "head-block1",
@@ -24,18 +23,12 @@ class NoContentDOM extends ParagraphFilter {
     "header",
     "footer",
     "side",
-    "aside",
-    "sidebar",
     "menu",
     "nav",
-    "navi",
-    "navigation",
-    "navbar",
     "banner",
     "logo",
     "pankuzu",
     "breadcrumb",
-    "breadcrumbs",
     "widget",
     "button",
   )
@@ -54,18 +47,11 @@ class NoContentDOM extends ParagraphFilter {
       return false
     }
 
-    val idSegments = css.splitIdByCase.toSet
-
-    filteringPartialMatchClassOrIdNames
-      .exists(name => idSegments.contains(name) || css.id.capitalize.contains(name.capitalize))
+    filteringPartialMatchClassOrIdNames.exists(name => css.lowerId.contains(name))
   }
 
   def partialMatchClasses(css: PathSegment): Boolean = {
-    val classSegments = css.splitClassesByCase.flatten.toSet
-
-    filteringPartialMatchClassOrIdNames.exists(name =>
-      classSegments.contains(name) || css.classes.exists(_.capitalize.contains(name.capitalize))
-    )
+    filteringPartialMatchClassOrIdNames.exists(name => css.lowerClasses.exists(_.contains(name)))
   }
 
   def containsTagWithIdAndClasses(
@@ -80,17 +66,15 @@ class NoContentDOM extends ParagraphFilter {
       val css = iter.next()
 
       if (
-        fullMatchCandidates
-          .exists(name => tagNames.contains(css.tag) && (css.id == name || css.classes.contains(name)))
+        tagNames.contains(css.tag)
+        && fullMatchCandidates.exists(name => css.id == name || css.classes.contains(name))
       ) {
         return true
       }
 
-      // check filtering keywords in snake case, camel case and kebab case
       if (
-        partialMatchCandidates.exists(name =>
-          tagNames.contains(css.tag) && (partialMatchIds(css) || partialMatchClasses(css))
-        )
+        tagNames.contains(css.tag)
+        && partialMatchCandidates.exists(name => partialMatchIds(css) || partialMatchClasses(css))
       ) {
         return true
       }

--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOM.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOM.scala
@@ -7,7 +7,9 @@ class NoContentDOM extends ParagraphFilter {
   final private val filteringDomNames: Seq[String] =
     Array("header", "footer", "aside", "nav", "noscript", "form")
 
-  final private val filteringFullMatchClassOrIdNames: Seq[String] = Array(
+  final private val DOMCandidatesForFiliteringClassOrId = Array("div", "p", "ul", "h1")
+
+  final private val filteringFullMatchClassOrIdCandidates: Seq[String] = Array(
     "left-box",
     "blog-title-inner",
     "globalheader",
@@ -38,6 +40,10 @@ class NoContentDOM extends ParagraphFilter {
     // "profile",
     "button",
   )
+
+  final private val filteringFullMatchClassOrIdNames =
+    filteringPartialMatchClassOrIdNames ++ filteringFullMatchClassOrIdCandidates ++ filteringFullMatchClassOrIdCandidates
+      .map(toCamelCase)
 
   def toCamelCase(s: String): String = {
     val words = s.split("-")
@@ -79,14 +85,11 @@ class NoContentDOM extends ParagraphFilter {
   }
 
   override def checkParagraph(p: Paragraph): Paragraph = {
-    val fullMatchCandidates =
-      filteringPartialMatchClassOrIdNames ++ filteringFullMatchClassOrIdNames ++ filteringFullMatchClassOrIdNames
-        .map(toCamelCase)
     if (
       p.containsTags(filteringDomNames) || containsTagWithIdAndClasses(
         p,
-        Seq("div", "p", "ul", "h1"),
-        fullMatchCandidates,
+        DOMCandidatesForFiliteringClassOrId,
+        filteringFullMatchClassOrIdNames,
         filteringPartialMatchClassOrIdNames
       )
     ) {

--- a/lib/src/test/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOMSpec.scala
+++ b/lib/src/test/scala/com/worksap/nlp/uzushio/lib/filters/NoContentDOMSpec.scala
@@ -32,6 +32,16 @@ class NoContentDOMSpec extends AnyFreeSpec {
       assert(filter.checkParagraph(p).remove != null)
     }
 
+    "sign remove for noscript tag paragraph" in {
+      val p = Paragraph("body>noscript", "test")
+      assert(filter.checkParagraph(p).remove != null)
+    }
+
+    "sign remove for form tag paragraph" in {
+      val p = Paragraph("body>form", "test")
+      assert(filter.checkParagraph(p).remove != null)
+    }
+
     "sign remove for div tag with header class paragraph" in {
       val p = Paragraph("body>div.header>p", "test")
       assert(filter.checkParagraph(p).remove != null)
@@ -39,6 +49,31 @@ class NoContentDOMSpec extends AnyFreeSpec {
 
     "sign remove for div tag with header id paragraph" in {
       val p = Paragraph("body>div#header>p", "test")
+      assert(filter.checkParagraph(p).remove != null)
+    }
+
+    "sign remove for div tag with header-test id paragraph" in {
+      val p = Paragraph("body>div#header-test>p", "test")
+      assert(filter.checkParagraph(p).remove != null)
+    }
+
+    "sign remove for div tag with breadcrumbs-test id paragraph" in {
+      val p = Paragraph("body>div.breadcrumbs-test>p", "test")
+      assert(filter.checkParagraph(p).remove != null)
+    }
+
+    "sign remove for div tag with widget_wrapper id paragraph" in {
+      val p = Paragraph("body>div#widget_wrapper>p", "test")
+      assert(filter.checkParagraph(p).remove != null)
+    }
+
+    "sign remove for div tag with testLogo id paragraph" in {
+      val p = Paragraph("body>div#testLogo>p", "test")
+      assert(filter.checkParagraph(p).remove != null)
+    }
+
+    "sign remove for div tag with headerTop id paragraph" in {
+      val p = Paragraph("body>div#headerTop>p", "test")
       assert(filter.checkParagraph(p).remove != null)
     }
   }


### PR DESCRIPTION
I enriched NoContentFilter.
The filtering DOM, classes, and ids criteria were determined by analyzing filter results of `filter=LargeFreqParagrap` and `filter=null`.

- split the DOM names variable into three variables (DOM list and full match classes and ids, partial match classes and ids)
- rewrite the logic matching classes and ids as a full match and partial match