### PR TITLE
fix statistical data merging logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
           cache: sbt
       - run: sbt "scalafmtCheck;test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,6 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: sbt
+      - name: Setup sbt launcher
+        uses: sbt/setup-sbt@v1
       - run: sbt "scalafmtCheck;test"

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,1 +1,2 @@
 -Xmx2G
+--add-exports=java.base/sun.nio.ch=ALL-UNNAMED

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You need to install Apache Spark, sbt, and Sudachi dictionary file.
 Download it from the [official page](https://spark.apache.org/downloads.html). 
 You can put it in PATH or use absolute paths for Spark startup scripts to launch Uzushio. 
 
-At the moment uzushio is built against: `spark 3.4.1` + `Scala 2.12.*`.
+At the moment uzushio is built against: `spark 3.5.3` + `Scala 2.12.*`.
 
 Check if `spark-submit --version` works.
 

--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/runners/MergeDedupStats.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/runners/MergeDedupStats.scala
@@ -92,7 +92,7 @@ object MergeDedupStats {
         explode($"tgtAll").as("srcHash"),
         $"tgtMin".as("tgtHash")
       )
-    ).where($"srcHash" =!= $"tgtHash").distinct().persist()
+    ).where($"srcHash" =!= $"tgtHash").distinct().localCheckpoint(eager = true)
 
     // Step 2b: collect all repr hash candidates to consider for updating
     // find all repr hashes which have distinct hashes
@@ -108,10 +108,10 @@ object MergeDedupStats {
       df.join(nonUnique, "hash").select($"reprHash".as("initReprHash"))
     }
 
-    val seedGroups = seedGroupsA.union(seedGroupsB).distinct().select(
+    val seedGroups = seedGroupsA.union(seedGroupsB).distinct().localCheckpoint(eager = true).select(
       $"initReprHash",
       $"initReprHash".as("newReprHash")
-    ).persist()
+    )
 
     // compute the correct remaps themselves iteratively
     // this will have false positives, but hopefully not much

--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/runners/MergeDedupStats.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/runners/MergeDedupStats.scala
@@ -6,6 +6,8 @@ import org.apache.spark.sql.types.LongType
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 import org.rogach.scallop.ScallopConf
 
+import scala.annotation.tailrec
+
 object MergeDedupStats {
 
   def run(spark: SparkSession, arg: Args): Unit = {
@@ -13,12 +15,13 @@ object MergeDedupStats {
 
     val inputData = spark.read.parquet(arg.input(): _*)
 
-    val merged = mergeStatisticDatasets(spark, inputData)
+    val remaps = arg.remaps.getOrElse(5)
+    val merged = mergeStatisticDatasets(spark, inputData, remaps)
 
     val filtered =
       if (arg.noOnes()) {
-        merged
-      } else merged.where($"nearFreq" > 1)
+        merged.where($"nearFreq" > 1)
+      } else merged
 
     val partitioned = filtered.repartition(arg.partitions(), $"hash")
       .sortWithinPartitions($"reprHash", $"hash")
@@ -26,52 +29,125 @@ object MergeDedupStats {
     partitioned.write.option("compression", "zstd").mode(SaveMode.Overwrite).parquet(arg.output())
   }
 
-  def mergeStatisticDatasets(spark: SparkSession, inputData: DataFrame): DataFrame = {
+  private[this] val clampLongToInt = udf((x: Long) => math.min(x, Int.MaxValue).toInt)
+    .asNonNullable()
+
+  @tailrec
+  def propagateRemaps(
+      spark: SparkSession,
+      groups: DataFrame,
+      updates: DataFrame,
+      iter: Int,
+      maxIters: Int
+  ): DataFrame = {
     import spark.implicits._
-    val clampLongToInt = udf((x: Long) => math.min(x, Int.MaxValue).toInt).asNonNullable()
+    val merged = groups.join(updates, groups.col("newReprHash") === updates.col("srcHash"), "left")
 
-    val combined = inputData.groupBy("hash").agg(
-      clampLongToInt(sum($"exactFreq".cast(LongType))).as("exactFreq"),
-      clampLongToInt(sum($"nearFreq".cast(LongType))).as("nearFreq"),
-      collect_list($"reprHash").as("reprHashes")
-    ).persist()
+    val newMapping = merged.select(
+      $"initReprHash",
+      coalesce($"tgtHash", $"newReprHash").as("newReprHash"),
+    ).groupBy("initReprHash").agg(
+      min("newReprHash").as("newReprHash")
+    ).where($"initReprHash" =!= $"newReprHash").persist()
 
-    val notUnique = combined.where(size($"reprHashes") > 1)
-
-    val remapReprHashes = notUnique.select("reprHashes").select(
-      array_min($"reprHashes").as("newReprHash"),
-      explode($"reprHashes").as("oldReprHash")
-    ).where($"newReprHash" =!= $"oldReprHash").groupBy($"oldReprHash")
-      .agg(min($"newReprHash").as("newReprHash"))
-
-    val intermediate = combined.select(
-      $"hash",
-      $"exactFreq",
-      $"nearFreq",
-      array_min($"reprHashes").as("reprHash")
-    ).persist()
-
-    val correctHashes = intermediate.join(remapReprHashes, $"reprHash" === $"oldReprHash", "left")
-      .select(
-        $"hash",
-        when($"oldReprHash".isNotNull, $"newReprHash").otherwise($"reprHash").as("reprHash"),
-        $"exactFreq",
-        $"nearFreq"
-      ).persist()
-
-    val correctFreqs = correctHashes.groupBy("reprHash").agg(
-      max($"nearFreq").as("nearFreq")
-    )
-
-    correctHashes.select("hash", "reprHash", "exactFreq").join(correctFreqs, "reprHash")
+    if (iter >= maxIters) {
+      newMapping.select(
+        $"initReprHash".as("srcReprHash"),
+        $"newReprHash".as("tgtReprHash")
+      )
+    } else {
+      propagateRemaps(spark, newMapping, updates, iter + 1, maxIters)
+    }
   }
 
+  def mergeStatisticDatasets(spark: SparkSession, df: DataFrame, maxRemaps: Int = 10): DataFrame = {
+    import spark.implicits._
+
+    // Step 1: Compute new frequencies that arise via merging
+    // Entries with the same hash are summed up
+    val aggregated = df.groupBy("hash").agg(
+      min("reprHash").as("newReprHash"),
+      clampLongToInt(sum($"exactFreq".cast(LongType))).as("newExactFreq"),
+      clampLongToInt(sum($"nearFreq".cast(LongType))).as("newNearFreq"),
+    ).persist()
+
+    // newReprHashes are incorrect at this point because transitive set merging is not applied yet
+
+    // Step 2: Compute mapping for transitive set merging
+    // We consider entries to contain updates if the "reprHash" value was changed during the first aggregation
+    val seedPreUpdates = df.join(aggregated, "hash").where($"reprHash" =!= $"newReprHash").select(
+      $"reprHash".as("srcHash"),
+      $"newReprHash".as("tgtHash")
+    ).groupBy("srcHash").agg(
+      collect_set($"tgtHash").as("tgtAll"),
+      min($"tgtHash").as("tgtMin")
+    )
+
+    // Step 2a: collect updates (e.g. we have hash 8 with reprs 1, 3, 8)
+    // first part collects the direct updates (e.g. 8 -> 1)
+    val seedUpdates = seedPreUpdates.select($"srcHash", $"tgtMin".as("tgtHash")).union(
+      // second part contains the internal updates
+      // second part will add 3 -> 1
+      seedPreUpdates.select(
+        explode($"tgtAll").as("srcHash"),
+        $"tgtMin".as("tgtHash")
+      )
+    ).where($"srcHash" =!= $"tgtHash").distinct().persist()
+
+    // Step 2b: collect all repr hash candidates to consider for updating
+    // find all repr hashes which have distinct hashes
+    val seedGroupsA = df.groupBy("reprHash").count().where($"count" > 1).select(
+      $"reprHash".as("initReprHash")
+    )
+
+    // find all reprs if hash has several of them in the merged dataset
+    val seedGroupsB = {
+      val nonUnique = df.groupBy("hash")
+        .agg(countDistinct("reprHash").as("count"))
+        .where($"count" > 1)
+
+      df.join(nonUnique, "hash")
+        .select($"reprHash".as("initReprHash"))
+    }
+
+    val seedGroups = seedGroupsA.union(seedGroupsB).distinct().select(
+      $"initReprHash",
+      $"initReprHash".as("newReprHash")
+    ).persist()
+
+    // compute the correct remaps themselves iteratively
+    // this will have false positives, but hopefully not much
+    // most merges should be correct after 5 iterations in non-degenerate cases
+    val remaps = propagateRemaps(spark, seedGroups, seedUpdates, 0, maxRemaps)
+
+    // finally apply remaps
+    val remappedHashes = aggregated.join(remaps, $"newReprHash" === $"srcReprHash", "left").select(
+      $"hash",
+      coalesce($"tgtReprHash", $"newReprHash").as("reprHash"),
+      $"newExactFreq".as("exactFreq"),
+      $"newNearFreq".as("nearFreq")
+    ).persist()
+
+    // Step 3: Correct nearFreq as max(nearFreq) inside the newly computed groups
+    val nearFreqCorrection = remappedHashes.groupBy("reprHash").agg(
+      max("nearFreq").as("nearFreq")
+    )
+
+    remappedHashes.select(
+      $"hash",
+      $"reprHash",
+      $"exactFreq"
+    ).join(nearFreqCorrection, "reprHash")
+  }
+
+  // noinspection TypeAnnotation
   class Args(args: Seq[String]) extends ScallopConf(args) {
     val input = opt[List[String]]()
     val output = opt[String]()
     val master = opt[String]()
     val partitions = opt[Int](default = Some(500))
     val noOnes = toggle(default = Some(false))
+    val remaps = opt[Int](default = Some(5))
     verify()
   }
 

--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/runners/MergeDedupStats.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/runners/MergeDedupStats.scala
@@ -102,12 +102,10 @@ object MergeDedupStats {
 
     // find all reprs if hash has several of them in the merged dataset
     val seedGroupsB = {
-      val nonUnique = df.groupBy("hash")
-        .agg(countDistinct("reprHash").as("count"))
+      val nonUnique = df.groupBy("hash").agg(countDistinct("reprHash").as("count"))
         .where($"count" > 1)
 
-      df.join(nonUnique, "hash")
-        .select($"reprHash".as("initReprHash"))
+      df.join(nonUnique, "hash").select($"reprHash".as("initReprHash"))
     }
 
     val seedGroups = seedGroupsA.union(seedGroupsB).distinct().select(

--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/utils/WarcFileReader.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/utils/WarcFileReader.scala
@@ -19,10 +19,11 @@ class WarcFileReader(conf: Configuration, filePath: Path) {
   private val fileSize = fs.getFileStatus(filePath).getLen
   private val fsin = {
     val rawStream = fs.open(filePath)
-    val wrapped = if (rawStream.markSupported()) {
-      rawStream
-    } else new BufferedInputStream(rawStream)
-    //noinspection UnstableApiUsage
+    val wrapped =
+      if (rawStream.markSupported()) {
+        rawStream
+      } else new BufferedInputStream(rawStream)
+    // noinspection UnstableApiUsage
     new CountingInputStream(wrapped)
   }
   private val reader = WARCReaderFactory.get(filePath.getName, fsin, true)

--- a/lib/src/main/scala/com/worksap/nlp/uzushio/lib/warc/WarcEntryParser.scala
+++ b/lib/src/main/scala/com/worksap/nlp/uzushio/lib/warc/WarcEntryParser.scala
@@ -1,11 +1,20 @@
 package com.worksap.nlp.uzushio.lib.warc
 
 import com.worksap.nlp.uzushio.lib.html.{AllTagMapper, ParagraphExtractor, ParseAbortException}
-import com.worksap.nlp.uzushio.lib.lang.{EstimationFailure, LangEstimation, LangTagSniffer, ProbableLanguage}
+import com.worksap.nlp.uzushio.lib.lang.{
+  EstimationFailure,
+  LangEstimation,
+  LangTagSniffer,
+  ProbableLanguage
+}
 import com.worksap.nlp.uzushio.lib.warc.WarcEntryParser.{logger, resolveEarliestDate}
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap
 import org.apache.commons.lang3.StringUtils
-import org.apache.hc.core5.http.impl.nio.{DefaultHttpResponseFactory, DefaultHttpResponseParser, SessionBufferAccess}
+import org.apache.hc.core5.http.impl.nio.{
+  DefaultHttpResponseFactory,
+  DefaultHttpResponseParser,
+  SessionBufferAccess
+}
 import org.apache.hc.core5.http.{HttpException, HttpMessage, MessageHeaders}
 import org.apache.tika.detect.EncodingDetector
 import org.apache.tika.exception.TikaException
@@ -17,7 +26,12 @@ import org.mozilla.universalchardet.UniversalDetector
 import org.slf4j.LoggerFactory
 
 import java.io.{ByteArrayInputStream, IOException, InputStream}
-import java.nio.charset.{Charset, IllegalCharsetNameException, StandardCharsets, UnsupportedCharsetException}
+import java.nio.charset.{
+  Charset,
+  IllegalCharsetNameException,
+  StandardCharsets,
+  UnsupportedCharsetException
+}
 import java.time.format.{DateTimeFormatter, DateTimeParseException}
 import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 import java.util

--- a/lib/src/test/scala/com/worksap/nlp/uzushio/lib/runners/MergeStatsSpec.scala
+++ b/lib/src/test/scala/com/worksap/nlp/uzushio/lib/runners/MergeStatsSpec.scala
@@ -1,15 +1,25 @@
 package com.worksap.nlp.uzushio.lib.runners
 
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{DataFrame, Encoder, SparkSession}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.freespec.AnyFreeSpec
 
 case class MergeItem(hash: Long, reprHash: Long, exactFreq: Int = 1, nearFreq: Int = 1)
 
 class MergeStatsSpec extends AnyFreeSpec with BeforeAndAfterAll {
-  private val session = SparkSession.builder().master("local[1]")
+
+  private lazy val session = SparkSession.builder().master("local[1]")
     .config("spark.sql.shuffle.partitions", "1").getOrCreate()
   import session.implicits._
+
+  private def df[T <: Product: Encoder](vals: T*): DataFrame = {
+    session.createDataset(vals).toDF()
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    assert(session != null)
+  }
 
   override def afterAll(): Unit = {
     super.afterAll()
@@ -17,21 +27,17 @@ class MergeStatsSpec extends AnyFreeSpec with BeforeAndAfterAll {
   }
 
   "can merge two datasets without remapping reprHashes" in {
-    val dataset1 = session.createDataset(
-      Seq(
-        MergeItem(1, 1, 1, 2),
-        MergeItem(2, 1, 1, 2),
-        MergeItem(3, 3),
-      )
-    ).toDF()
-    val dataset2 = session.createDataset(
-      Seq(
-        MergeItem(1, 1, 1, 2),
-        MergeItem(4, 1, 1, 2),
-        MergeItem(3, 3, 1, 2),
-        MergeItem(5, 3, 1, 2)
-      )
-    ).toDF()
+    val dataset1 = df(
+      MergeItem(1, 1, 1, 2),
+      MergeItem(2, 1, 1, 2),
+      MergeItem(3, 3),
+    )
+    val dataset2 = df(
+      MergeItem(1, 1, 1, 2),
+      MergeItem(4, 1, 1, 2),
+      MergeItem(3, 3, 1, 2),
+      MergeItem(5, 3, 1, 2)
+    )
 
     val merged = MergeDedupStats.mergeStatisticDatasets(session, dataset1.union(dataset2))
       .orderBy($"hash".asc, $"reprHash".asc).as[MergeItem].take(100)
@@ -108,15 +114,13 @@ class MergeStatsSpec extends AnyFreeSpec with BeforeAndAfterAll {
     assert(merged === result)
   }
 
-  "TODO incorrectly calculates " in {
+  "propagates nearHash from other dataset" in {
     val dataset1 = session.createDataset(
       Seq(
         MergeItem(7, 1, 1, 2),
         MergeItem(8, 2, 1, 2),
-
         MergeItem(7, 5, 1, 3),
         MergeItem(8, 5, 1, 3),
-
         MergeItem(7, 7, 1, 4),
         MergeItem(8, 8, 1, 4),
       )
@@ -126,64 +130,56 @@ class MergeStatsSpec extends AnyFreeSpec with BeforeAndAfterAll {
         MergeItem(1, 1, 1, 4),
         MergeItem(2, 2, 1, 4),
         MergeItem(5, 5, 1, 4),
+        MergeItem(6, 6, 1, 1),
+        MergeItem(9, 6, 3, 3),
       )
     ).toDF()
 
-    val merged = MergeDedupStats.mergeStatisticDatasets(session, dataset1.union(dataset2))
+    val merged = MergeDedupStats.mergeStatisticDatasets(session, dataset1.union(dataset2).coalesce(1))
       .orderBy($"hash".asc, $"reprHash".asc).as[MergeItem].take(100)
 
     val result = Seq(
       MergeItem(1, 1, 1, 9),
-      MergeItem(2, 2, 1, 9), // reprHash should be 1, but calculating that correctly is convoluted
+      MergeItem(2, 1, 1, 9),
       MergeItem(5, 1, 1, 9),
+      MergeItem(6, 6, 1, 3),
       MergeItem(7, 1, 3, 9),
-      MergeItem(8, 2, 3, 9),
+      MergeItem(8, 1, 3, 9),
+      MergeItem(9, 6, 3, 3),
     )
-
-//    val xx = dataset1.union(dataset2).groupBy("hash").agg(
-//      sum($"exactFreq").as("exactFreq"),
-//      sum($"nearFreq").as("nearFreq"),
-//      collect_list($"reprHash").as("reprHashes")
-//    ).where(size($"reprHashes") > 1).select("reprHashes").select(
-//      array_min($"reprHashes").as("newReprHash"),
-//      explode($"reprHashes").as("oldReprHash")
-//    ).distinct()
-
-//    print(xx.take(10).toSeq)
 
     assert(merged === result)
   }
 
   // current implementation fails this spec and it is unimplementable
   // need to focus on correctness of mapping with merging counts as a best effort
-  "can merge three datasets with remapping reprHashes" ignore {
-    val dataset1 = session.createDataset(
-      Seq(
-        MergeItem(1, 1, 1, 2),
-        MergeItem(2, 1, 1, 2),
-      )
-    ).toDF()
-    val dataset2 = session.createDataset(
-      Seq(
-        MergeItem(2, 2, 1, 2),
-        MergeItem(3, 2, 1, 2),
-      )
-    ).toDF()
-    val dataset3 = session.createDataset(
-      Seq(
-        MergeItem(3, 3, 1, 2),
-        MergeItem(4, 3, 1, 2),
-      )
-    ).toDF()
+  "can merge three datasets with remapping reprHashes" in {
+    val ds1 = df(
+      MergeItem(1, 1, 1, 2),
+      MergeItem(2, 1, 1, 2),
+    )
 
-    val merged = MergeDedupStats.mergeStatisticDatasets(session, dataset1.union(dataset2).union(dataset3))
-      .orderBy($"hash".asc, $"reprHash".asc).as[MergeItem].take(100)
+    val ds2 = df(
+      MergeItem(2, 2, 1, 2),
+      MergeItem(3, 2, 1, 2),
+    )
+
+    val ds3 = df(
+      MergeItem(3, 3, 1, 2),
+      MergeItem(4, 3, 1, 2),
+    )
+
+    val merged = MergeDedupStats.mergeStatisticDatasets(
+      spark = session,
+      df = ds1.union(ds2).union(ds3).coalesce(1),
+      maxRemaps = 2
+    ).orderBy($"hash".asc, $"reprHash".asc).as[MergeItem].take(100)
 
     val result = Seq(
-      MergeItem(1, 1, 1, 6),
-      MergeItem(2, 1, 2, 6),
-      MergeItem(3, 1, 2, 6),
-      MergeItem(4, 1, 1, 6),
+      MergeItem(1, 1, 1, 4),
+      MergeItem(2, 1, 2, 4),
+      MergeItem(3, 1, 2, 4),
+      MergeItem(4, 1, 1, 4),
     )
 
     assert(merged === result)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -19,9 +19,9 @@ object Build {
     publishTo := None
   )
   val V = new {
-    val scala212 = "2.12.18"
-    val scala3 = "3.3.1"
-    val spark = "3.4.1"
+    val scala212 = "2.12.20"
+    val scala3 = "3.3.4"
+    val spark = "3.5.4"
   }
   val lintSettings = Def.settings {
     scalacOptions ++= (


### PR DESCRIPTION
This PR makes statistical data merge logic correctly merge transitive and partially intersecting sets.

See tests.

Notation: pre-merged sets are in brackets, individual elements are noted with letters.

Now situations like:
* (A, B, C), (B, C, D), (D, E, F) -> (A, B, C, D, E , F)
* (A, G, H), (B, F, H), (C, H, X) -> (A, B, C, G, H, X) 
are handled correctly.

Also fixes the `--no-ones` flag which had its meaning inversed :|

Also bumps spark/scala versions.

@mh-northlander you may want to see this